### PR TITLE
Fix links to mysten docs

### DIFF
--- a/advanced-topics/BCS_encoding/lessons/BCS_encoding.md
+++ b/advanced-topics/BCS_encoding/lessons/BCS_encoding.md
@@ -160,7 +160,7 @@ Now, let's write the function to deserialize an object in a Sui contract.
 
 ```
 
-The varies `peel_*` methods in Sui Frame [`bcs` module](https://github.com/MystenLabs/sui/blob/main/crates/sui-framework/docs/sui-framework/bcs.md) are used to "peel" each individual field from the BCS serialized bytes. Note that the order we peel the fields must be exactly the same as the order of the fields in the struct definition. 
+The varies `peel_*` methods in Sui Frame [`bcs` module](https://github.com/MystenLabs/sui/blob/main/crates/sui-framework/docs/sui/bcs.md) are used to "peel" each individual field from the BCS serialized bytes. Note that the order we peel the fields must be exactly the same as the order of the fields in the struct definition. 
 
 _Quiz: Why are the results not the same from the first two `peel_address` calls on the same `bcs` object?_
 

--- a/unit-one/lessons/4_functions.md
+++ b/unit-one/lessons/4_functions.md
@@ -55,5 +55,5 @@ We can define our minting function in the Hello World example as the following:
     }
 ```
 
-This function simply creates a new instance of the `HelloWorldObject` custom type, then uses the Sui system [`public_transfer`](https://github.com/MystenLabs/sui/blob/main/crates/sui-framework/docs/sui-framework/transfer.md#function-public_transfer) function to send it to the transaction caller. 
+This function simply creates a new instance of the `HelloWorldObject` custom type, then uses the Sui system [`public_transfer`](https://github.com/MystenLabs/sui/blob/main/crates/sui-framework/docs/sui/transfer.md#function-public_transfer) function to send it to the transaction caller. 
 

--- a/unit-three/lessons/1_sui_framework.md
+++ b/unit-three/lessons/1_sui_framework.md
@@ -4,20 +4,20 @@ A common use case for smart contracts is issuing custom fungible tokens (such as
 
 ## Sui Framework
 
-[The Sui Framework](https://github.com/MystenLabs/sui/tree/main/crates/sui-framework/docs) is Sui's specific implementation of the Move VM. It contains Sui's native API's including its implementation of the Move standard library, as well as Sui-specific operations such as [crypto primitives](https://github.com/MystenLabs/sui/blob/main/crates/sui-framework/docs/sui-framework/groth16.md) and Sui's implementation of [data structures](https://github.com/MystenLabs/sui/blob/main/crates/sui-framework/docs/sui-framework/url.md) at the framework level. 
+[The Sui Framework](https://github.com/MystenLabs/sui/tree/main/crates/sui-framework/docs) is Sui's specific implementation of the Move VM. It contains Sui's native API's including its implementation of the Move standard library, as well as Sui-specific operations such as [crypto primitives](https://github.com/MystenLabs/sui/blob/main/crates/sui-framework/docs/sui/groth16.md) and Sui's implementation of [data structures](https://github.com/MystenLabs/sui/blob/main/crates/sui-framework/docs/sui/url.md) at the framework level. 
 
 An implementation of a custom fungible token in Sui will heavily leverage some of the libraries in the Sui Framework. 
 
 ## `sui::coin`
 
-The main library we will use to implement a custom fungible token on Sui is the [`sui::coin`](https://github.com/MystenLabs/sui/blob/main/crates/sui-framework/docs/sui-framework/coin.md) module. 
+The main library we will use to implement a custom fungible token on Sui is the [`sui::coin`](https://github.com/MystenLabs/sui/blob/main/crates/sui-framework/docs/sui/coin.md) module. 
 
 The resources or methods we will directly use in our fungible token example are:
 
-- Resource: [Coin](https://github.com/MystenLabs/sui/blob/main/crates/sui-framework/docs/sui-framework/coin.md#resource-coin)
-- Resource: [TreasuryCap](https://github.com/MystenLabs/sui/blob/main/crates/sui-framework/docs/sui-framework/coin.md#resource-treasurycap)
-- Resource: [CoinMetadata](https://github.com/MystenLabs/sui/blob/main/crates/sui-framework/docs/sui-framework/coin.md#resource-coinmetadata)
-- Method: [coin::create_currency](https://github.com/MystenLabs/sui/blob/main/crates/sui-framework/docs/sui-framework/coin.md#0x2_coin_create_currency)
+- Resource: [Coin](https://github.com/MystenLabs/sui/blob/main/crates/sui-framework/docs/sui/coin.md#resource-coin)
+- Resource: [TreasuryCap](https://github.com/MystenLabs/sui/blob/main/crates/sui-framework/docs/sui/coin.md#resource-treasurycap)
+- Resource: [CoinMetadata](https://github.com/MystenLabs/sui/blob/main/crates/sui-framework/docs/sui/coin.md#resource-coinmetadata)
+- Method: [coin::create_currency](https://github.com/MystenLabs/sui/blob/main/crates/sui-framework/docs/sui/coin.md#0x2_coin_create_currency)
 
 We will revisit each of these in more depth after introducing some new concepts in the next few sections. 
 

--- a/unit-three/lessons/4_the_coin_resource_and_create_currency.md
+++ b/unit-three/lessons/4_the_coin_resource_and_create_currency.md
@@ -15,7 +15,7 @@ public struct Coin<phantom T> has key, store {
 
 The `Coin` resource type is a struct that has a generic type `T` and two fields, `id` and `balance`. `id` is of the type `sui::object::UID`, which we have already seen before. 
 
-`balance` is of the type [`sui::balance::Balance`](https://github.com/MystenLabs/sui/blob/main/crates/sui-framework/docs/sui-framework/balance.md#0x2_balance_Balance), and is [defined](https://github.com/MystenLabs/sui/blob/main/crates/sui-framework/packages/sui-framework/sources/balance.move#L29) as:
+`balance` is of the type [`sui::balance::Balance`](https://github.com/MystenLabs/sui/blob/main/crates/sui-framework/docs/sui/balance.md#0x2_balance_Balance), and is [defined](https://github.com/MystenLabs/sui/blob/main/crates/sui-framework/packages/sui-framework/sources/balance.move#L29) as:
 
 ```rust 
 public struct Balance<phantom T> has store {

--- a/unit-three/lessons/6_clock_and_locked_coin.md
+++ b/unit-three/lessons/6_clock_and_locked_coin.md
@@ -4,7 +4,7 @@ In the second fungible token example, we will introduce how to obtain time on-ch
 
 ## Clock 
 
-Sui Framework has a native [clock module](https://github.com/MystenLabs/sui/blob/main/crates/sui-framework/docs/sui-framework/clock.md) that makes timestamps available in Move smart contracts. 
+Sui Framework has a native [clock module](https://github.com/MystenLabs/sui/blob/main/crates/sui-framework/docs/sui/clock.md) that makes timestamps available in Move smart contracts. 
 
 The main method that you will need to access is the following: 
 
@@ -12,9 +12,9 @@ The main method that you will need to access is the following:
 public fun timestamp_ms(clock: &clock::Clock): u64
 ```
 
-the [`timestamp_ms`](https://github.com/MystenLabs/sui/blob/main/crates/sui-framework/docs/sui-framework/clock.md#0x2_clock_timestamp_ms) function returns the current system timestamp, as a running total of milliseconds since an arbitrary point in the past.
+the [`timestamp_ms`](https://github.com/MystenLabs/sui/blob/main/crates/sui-framework/docs/sui/clock.md#0x2_clock_timestamp_ms) function returns the current system timestamp, as a running total of milliseconds since an arbitrary point in the past.
 
-The [`clock`](https://github.com/MystenLabs/sui/blob/main/crates/sui-framework/docs/sui-framework/clock.md#0x2_clock_Clock) object has a special reserved identifier, `0x6`, that needs to be passed into function calls using it as one of the inputs. 
+The [`clock`](https://github.com/MystenLabs/sui/blob/main/crates/sui-framework/docs/sui/clock.md#0x2_clock_Clock) object has a special reserved identifier, `0x6`, that needs to be passed into function calls using it as one of the inputs. 
 
 ## Locked Coin
 


### PR DESCRIPTION
A bunch of links pointing to the sui framework docs were broken bc of a folder name change